### PR TITLE
add patch to fall back to find sip-distinfo if its not in the same pa…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,11 @@ source:
   patches:
     - patches/0001-Use-conda-sysroot-when-building-recipes.patch
     - patches/0002-disable-test-execution-cross.patch
+    - patches/0003-find-sip-distinfo.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - pyqt-bundle = pyqtbuild.bundle.bundle_main:main

--- a/recipe/patches/0003-find-sip-distinfo.patch
+++ b/recipe/patches/0003-find-sip-distinfo.patch
@@ -1,0 +1,14 @@
+diff --git a/pyqtbuild/builder.py b/pyqtbuild/builder.py
+index 3f35a7f..7133972 100644
+--- a/pyqtbuild/builder.py
++++ b/pyqtbuild/builder.py
+@@ -60,6 +60,9 @@ class QmakeBuilder(Builder):
+                         os.path.abspath(os.path.dirname(sys.argv[0])),
+                         self._sip_distinfo)
+ 
++                if not os.path.exists(self._sip_distinfo):
++                    self._sip_distinfo = self._find_exe('sip-distinfo')
++
+             # Check we have a qmake.
+             if self.qmake is None:
+                 self.qmake = self._find_exe('qmake')


### PR DESCRIPTION
There is some flawed logic in pyqt-builder that expects `sip-distinfo` in a weird path (for me it was something like `pep517/.../_inprocess/sip-distinfo`. 

This seems to only affect osx-arm64 (native or cross-compiling).