### PR TITLE
Allow empty string for CONDA_BUILD_CROSS_COMPILATION envvar

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - pyqt-bundle = pyqtbuild.bundle.bundle_main:main

--- a/recipe/patches/0002-disable-test-execution-cross.patch
+++ b/recipe/patches/0002-disable-test-execution-cross.patch
@@ -4,7 +4,7 @@
          if test_exe is None:
              return False
  
-+        if bool(int(os.environ.get('CONDA_BUILD_CROSS_COMPILATION', '0'))):
++        if bool(int(os.environ.get("CONDA_BUILD_CROSS_COMPILATION") or 0)):
 +            run_test = False
 +
          # If the test doesn't need to be run then we are done.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Linux64 recently started to fail because `CONDA_BUILD_CROSS_COMPILATION` is now set to an empty string on build (it might have been explicitly set as `0` before?).

```
  File "/home/conda/feedstock_root/build_artifacts/pyqt6-split_1766520735470/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/python3.14/site-packages/pyqtbuild/bindings.py", line 174, in is_buildable
    if bool(int(os.environ.get('CONDA_BUILD_CROSS_COMPILATION', '0'))):
            ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: ''
```

This PR address this by ensuring that: 1) if unset, set to 0; 2) if falsy (by empty string or 0), also set to 0